### PR TITLE
Make onclose an option.

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,7 +49,15 @@ type Client struct {
 	err       error
 }
 
-func NewClient(conn net.Conn) *Client {
+type ClientOpts func(c *Client)
+
+func WithOnClose(onClose func()) ClientOpts {
+	return func(c *Client) {
+		c.closeFunc = onClose
+	}
+}
+
+func NewClient(conn net.Conn, opts ...ClientOpts) *Client {
 	c := &Client{
 		codec:     codec{},
 		conn:      conn,
@@ -58,6 +66,10 @@ func NewClient(conn net.Conn) *Client {
 		closed:    make(chan struct{}),
 		done:      make(chan struct{}),
 		closeFunc: func() {},
+	}
+
+	for _, o := range opts {
+		o(c)
 	}
 
 	go c.run()
@@ -139,11 +151,6 @@ func (c *Client) Close() error {
 	})
 
 	return nil
-}
-
-// OnClose allows a close func to be called when the server is closed
-func (c *Client) OnClose(closer func()) {
-	c.closeFunc = closer
 }
 
 type message struct {


### PR DESCRIPTION
Make `OnClose` an create option instead of a separate function.

`NewClient` starts a goroutine, which calls `closeFunc` before exit.

Setting `closeFunc` after `NewClient` separately introduces a race condition:
1) The race condition can cause unexpected behavior, e.g. the function is not fully copied before being invoked;
2) There is no way to guarantee a `closeFunc` is called given that the connection may be gone before `OnClose` is set.

Signed-off-by: Lantao Liu <lantaol@google.com>