### PR TITLE
Keep OnClose (deprecated) for backward compat

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,6 +51,7 @@ type Client struct {
 
 type ClientOpts func(c *Client)
 
+// WithOnClose sets a close func to be called when the server is closed
 func WithOnClose(onClose func()) ClientOpts {
 	return func(c *Client) {
 		c.closeFunc = onClose
@@ -151,6 +152,12 @@ func (c *Client) Close() error {
 	})
 
 	return nil
+}
+
+// OnClose allows a close func to be called when the server is closed
+// Deprecated: use NewClient(con, WithOnClose(closer)) instead
+func (c *Client) OnClose(closer func()) {
+	c.closeFunc = closer
 }
 
 type message struct {


### PR DESCRIPTION
commit ba15956d22fc5bfe9dd6caaefcc013cd29da38b7 removed the OnClose function in favor of an WithOnClose option.

This patch adds bach the old function, but marks it deprecated, to easify upgrading this dependency without breaking.
