### PR TITLE
Client.Call(): do not return error if no Status is set (gRPC v1.23 and up)

### DIFF
--- a/client.go
+++ b/client.go
@@ -134,11 +134,11 @@ func (c *Client) Call(ctx context.Context, service, method string, req, resp int
 		return err
 	}
 
-	if cresp.Status == nil {
-		return errors.New("no status provided on response")
+	if cresp.Status != nil {
+		return status.ErrorProto(cresp.Status)
 	}
 
-	return status.ErrorProto(cresp.Status)
+	return nil
 }
 
 func (c *Client) dispatch(ctx context.Context, req *Request, resp *Response) error {


### PR DESCRIPTION
To account for https://github.com/grpc/grpc-go/commit/5da5b1f225a310a6e36fe01fb7e0883e04cda2e0 (https://github.com/grpc/grpc-go/pull/2929),
which is part of gRPC v1.23.0 and up, and after which gRPC no longer sets a
Status if no error occured.
