### PR TITLE
ttrpc: fix the issue of marshaling on nil will crash the server

### DIFF
--- a/services.go
+++ b/services.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"unsafe"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
@@ -95,6 +96,10 @@ func (s *serviceSet) dispatch(ctx context.Context, serviceName, methodName strin
 		return nil, err
 	}
 
+	if isNil(resp) {
+		return nil, errors.New("ttrpc: marshal called with nil")
+	}
+
 	switch v := resp.(type) {
 	case proto.Message:
 		r, err := proto.Marshal(v)
@@ -153,4 +158,8 @@ func convertCode(err error) codes.Code {
 
 func fullPath(service, method string) string {
 	return "/" + path.Join(service, method)
+}
+
+func isNil(resp interface{}) bool {
+	return (*[2]uintptr)(unsafe.Pointer(&resp))[1] == 0
 }


### PR DESCRIPTION
Since proto.Marshal() on nil will crash runtime, thus
it's should check 'resp' before marshaling on it. If it's
nil, return directly.

Signed-off-by: lifupan <lifupan@gmail.com>