### PR TITLE
.travis: don't call go get if there is go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ go:
   - "1.12.x"
 
 install:
-  - go get -u github.com/vbatts/git-validation
-  - go get -u github.com/kunalkushwaha/ltag
-  - go get -t ./...
+  # Don't change local go.{mod, sum} by go get tools.
+  #
+  # ref: https://github.com/golang/go/issues/27643
+  - pushd ..; go get -u github.com/vbatts/git-validation; popd
+  - pushd ..; go get -u github.com/kunalkushwaha/ltag; popd
 
 before_script:
   - pushd ..; git clone https://github.com/containerd/project; popd


### PR DESCRIPTION
when enable go module, go get will update the required version. It is
not supported to run in CI.

More info: golang/go#27643.

Signed-off-by: Wei Fu <fuweid89@gmail.com>