### PR TITLE
server: fix the issue if connections leak

### DIFF
--- a/server.go
+++ b/server.go
@@ -216,6 +216,13 @@ func (s *Server) delConnection(c *serverConn) {
 	delete(s.connections, c)
 }
 
+func (s *Server) countConnection() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return len(s.connections)
+}
+
 func (s *Server) closeIdleConns() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/server.go
+++ b/server.go
@@ -209,6 +209,13 @@ func (s *Server) addConnection(c *serverConn) {
 	s.connections[c] = struct{}{}
 }
 
+func (s *Server) delConnection(c *serverConn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.connections, c)
+}
+
 func (s *Server) closeIdleConns() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -313,6 +320,7 @@ func (c *serverConn) run(sctx context.Context) {
 	defer c.conn.Close()
 	defer cancel()
 	defer close(done)
+	defer c.server.delConnection(c)
 
 	go func(recvErr chan error) {
 		defer close(recvErr)


### PR DESCRIPTION
When the connection closed, it should delete
the connection from server's connections map.

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>