### PR TITLE
travis: add go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 
 go:
   - "1.13.x"
+  - "1.15.x"
 
 install:
   # Don't change local go.{mod, sum} by go get tools.


### PR DESCRIPTION
I saw https://github.com/containerd/ttrpc/issues/62 was reported to panic on Go 1.15, so adding that too travis. Kept Go 1.13 for now, as that's still used by containerd