### PR TITLE
fix unix domain socket connection leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -345,9 +345,9 @@ func filterCloseErr(err error) error {
 	switch {
 	case err == nil:
 		return nil
-	case err == io.EOF:
-		return ErrClosed
 	case errors.Cause(err) == io.EOF:
+		return ErrClosed
+	case errors.Cause(err) == io.ErrUnexpectedEOF:
 		return ErrClosed
 	case strings.Contains(err.Error(), "use of closed network connection"):
 		return ErrClosed

--- a/client.go
+++ b/client.go
@@ -345,9 +345,9 @@ func filterCloseErr(err error) error {
 	switch {
 	case err == nil:
 		return nil
-	case errors.Cause(err) == io.EOF:
+	case errors.Is(err, io.EOF):
 		return ErrClosed
-	case errors.Cause(err) == io.ErrUnexpectedEOF:
+	case errors.Is(err, io.ErrUnexpectedEOF):
 		return ErrClosed
 	case strings.Contains(err.Error(), "use of closed network connection"):
 		return ErrClosed


### PR DESCRIPTION
When server reply data to client, then client close connection and have not received the data, server will receive a  ECONNRESET error. At the moment, the code will ignore it and hang in shutdown channel.

After code fixed, it will return when happen broken  connection with no error message print.


Signed-off-by: blade <blade.shen@ucloud.cn>