### PR TITLE
Add support for fd passing

### DIFF
--- a/fd_test.go
+++ b/fd_test.go
@@ -1,0 +1,146 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ttrpc
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSendRecvFd(t *testing.T) {
+	var (
+		ctx, cancel    = context.WithDeadline(context.Background(), time.Now().Add(1*time.Minute))
+		addr, listener = newTestListener(t)
+	)
+
+	defer cancel()
+
+	// Spin up an out of process ttrpc server
+	if err := listenerCmd(ctx, t.Name(), listener); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		client, cleanup = newTestClient(t, addr)
+
+		tclient = testFdClient{client}
+	)
+	defer cleanup()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err, "error creating test pipe")
+	}
+	defer r.Close()
+
+	type readResp struct {
+		buf []byte
+		err error
+	}
+
+	expect := []byte("hello")
+
+	chResp := make(chan readResp, 1)
+	go func() {
+		buf := make([]byte, len(expect))
+		_, err := io.ReadFull(r, buf)
+		chResp <- readResp{buf, err}
+	}()
+
+	if err := tclient.Test(ctx, w); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case resp := <-chResp:
+		if resp.err != nil {
+			t.Error(err)
+		}
+		if !bytes.Equal(resp.buf, expect) {
+			t.Fatalf("got unexpected respone data, exepcted %q, got %q", string(expect), string(resp.buf))
+		}
+	}
+}
+
+type testFdPayload struct {
+	Fds []int64 `protobuf:"varint,1,opt,name=fds,proto3"`
+}
+
+func (r *testFdPayload) Reset()         { *r = testFdPayload{} }
+func (r *testFdPayload) String() string { return fmt.Sprintf("%+#v", r) }
+func (r *testFdPayload) ProtoMessage()  {}
+
+type testingServerFd struct {
+	respData []byte
+}
+
+func (s *testingServerFd) Test(ctx context.Context, req *testFdPayload) error {
+	for i, fd := range req.Fds {
+		f := os.NewFile(uintptr(fd), "TEST_FILE_"+strconv.Itoa(i))
+		go func() {
+			f.Write(s.respData)
+			f.Close()
+		}()
+	}
+
+	return nil
+}
+
+type testFdClient struct {
+	client *Client
+}
+
+func (c *testFdClient) Test(ctx context.Context, files ...*os.File) error {
+	fds, err := c.client.Sendfd(ctx, files)
+	if err != nil {
+		return fmt.Errorf("error sending fds: %w", err)
+	}
+
+	tp := testFdPayload{}
+	return c.client.Call(ctx, "Test", "Test", &testFdPayload{Fds: fds}, &tp)
+}
+
+func handleTestSendRecvFd(l net.Listener) error {
+	s, err := NewServer()
+	if err != nil {
+		return err
+	}
+	testImpl := &testingServerFd{respData: []byte("hello")}
+
+	s.Register("Test", map[string]Method{
+		"Test": func(ctx context.Context, unmarshal func(interface{}) error) (interface{}, error) {
+			req := &testFdPayload{}
+
+			if err := unmarshal(req); err != nil {
+				return nil, err
+			}
+
+			return &testFdPayload{}, testImpl.Test(ctx, req)
+		},
+	})
+
+	return s.Serve(context.TODO(), l)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ttrpc
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	var ttrpcListener bool
+	flag.BoolVar(&ttrpcListener, "listener", false, "Makes the test binary run a ttrpc listener for testing purposes instead of running a test")
+	flag.Parse()
+
+	if ttrpcListener {
+		handleListenerCmd()
+	}
+
+	os.Exit(m.Run())
+}
+
+var listenerHandlers = map[string]func(net.Listener) error{
+	"TestSendRecvFd": handleTestSendRecvFd,
+}
+
+// Starts a ttrpc serverout of process.
+//
+// The caller is responsible for creating the listener.
+// The listener implementation must be able to be converted to an *os.File
+// The passed in listtener fd will be closed when this function returns
+//   (because the fd is copied and handed off to the other process).
+func listenerCmd(ctx context.Context, handler string, l net.Listener) error {
+	defer l.Close()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-listener=true")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(cmd.Env, "TEST_HANDLER="+handler)
+
+	f, err := l.(fileListener).File()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	cmd.ExtraFiles = []*os.File{f}
+	return cmd.Start()
+}
+
+type fileListener interface {
+	File() (*os.File, error)
+}
+
+func handleListenerCmd() {
+	h := listenerHandlers[os.Getenv("TEST_HANDLER")]
+	l, err := net.FileListener(os.NewFile(3, "TEST_LISTENER"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	if err := h(l); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(2)
+	}
+	os.Exit(0)
+}

--- a/server_test.go
+++ b/server_test.go
@@ -103,6 +103,8 @@ func init() {
 	proto.RegisterType((*testPayload)(nil), "testPayload")
 	proto.RegisterType((*Request)(nil), "Request")
 	proto.RegisterType((*Response)(nil), "Response")
+	proto.RegisterType((*FileList)(nil), "FileList")
+	proto.RegisterType((*testFdPayload)(nil), "testFdPayload")
 }
 
 func TestServer(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -61,3 +61,25 @@ type KeyValue struct {
 func (m *KeyValue) Reset()         { *m = KeyValue{} }
 func (*KeyValue) ProtoMessage()    {}
 func (m *KeyValue) String() string { return fmt.Sprintf("%+#v", m) }
+
+type FileList struct {
+	List []*File `protobuf:"bytes,1,rep,name=list,proto3"`
+}
+
+func (r *FileList) Reset()         { *r = FileList{} }
+func (r *FileList) String() string { return fmt.Sprintf("%+#v", r) }
+func (r *FileList) ProtoMessage()  {}
+
+// File represents a file descriptor that is transferred.
+// Once the file descriptor is passed, the server should be able to call `os.NewFile(f.Fileno, f.Name)`
+// The Fileno field will be filled in by the server side after the descriptor has been passed.
+type File struct {
+	// Name is the name to be used when accepting the file descriptor
+	Name string `protobuf:"bytes,1,opt,name=name,proto3"`
+	// Fileno is the file descriptor id/pointer
+	Fileno int64 `protobuf:"varint,2,opt,name=timeout_nano,proto3"`
+}
+
+func (r *File) Reset()         { *r = File{} }
+func (r *File) String() string { return fmt.Sprintf("%+#v", r) }
+func (r *File) ProtoMessage()  {}


### PR DESCRIPTION
This adds a new message type for passing file descriptors.
How this works is:

1. Client sends a message with a header for messageTypeFileDescriptor
   along with the list of descriptors to be sent
2. Client sends 2nd message to actually pass along the descriptors
   (needed for unix sockets).
3. Server sees the message type and waits to receive the fd's.
4. Once fd's are seen the server responds with the real fd numbers that
   are used which an application can use in future calls.

To accomplish this reliably (on unix sockets) I had to drop the usage of
the bufio.Reader because we need to ensure exact message boundaries.

Within ttrpc this only support unix sockets and `net.Conn` implementations
that implement `SendFds`/`ReceiveFds` (this interface is totally
invented here).

Something to consider, I have not attempted to do fd passing on Windows
which will need other mechanisms entirely (and the conn's provided by
winio are not sufficient for fd passing).
I'm not sure if this new messaging will actually work on a Windows
implementation.

Perhaps the message tpye should be specifically for unix sockets? I'm
not sure how this would be enforced at the moment except by checking if
the `net.Conn` is a `*net.UnixConn`.

Closes #74