### PR TITLE
Return Unimplemented when services or methods are not implemented

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -136,7 +136,7 @@ func TestServer(t *testing.T) {
 	}
 }
 
-func TestServerNotFound(t *testing.T) {
+func TestServerUnimplemented(t *testing.T) {
 	var (
 		ctx             = context.Background()
 		server          = mustServer(t)(NewServer())
@@ -155,7 +155,7 @@ func TestServerNotFound(t *testing.T) {
 		t.Fatalf("expected error from non-existent service call")
 	} else if status, ok := status.FromError(err); !ok {
 		t.Fatalf("expected status present in error: %v", err)
-	} else if status.Code() != codes.NotFound {
+	} else if status.Code() != codes.Unimplemented {
 		t.Fatalf("expected not found for method")
 	}
 

--- a/services.go
+++ b/services.go
@@ -116,12 +116,12 @@ func (s *serviceSet) dispatch(ctx context.Context, serviceName, methodName strin
 func (s *serviceSet) resolve(service, method string) (Method, error) {
 	srv, ok := s.services[service]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "service %v", service)
+		return nil, status.Errorf(codes.Unimplemented, "service %v", service)
 	}
 
 	mthd, ok := srv.Methods[method]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "method %v", method)
+		return nil, status.Errorf(codes.Unimplemented, "method %v", method)
 	}
 
 	return mthd, nil


### PR DESCRIPTION
gRPC has UNIMPLEMENTED status code that indicates a requested method
is not implemented. However ttrpc was returning codes.NotFound which
could be returned when a request entity was not there.

This fix changes the status code from codes.NotFound to
codes.Unimplemented to disambiguate and be more compatible with gRPC.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>