### PR TITLE
Make "go test" and "go build" work on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,12 @@ on:
 jobs:
 
   build:
-    name: TTRPC CI
-    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, macos-10.15]
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
 

--- a/example/cmd/handshaker_linux.go
+++ b/example/cmd/handshaker_linux.go
@@ -1,0 +1,23 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import ttrpc "github.com/containerd/ttrpc"
+
+func defaultHandshaker() ttrpc.Handshaker {
+	return ttrpc.UnixSocketRequireSameUser()
+}

--- a/example/cmd/handshaker_other.go
+++ b/example/cmd/handshaker_other.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import ttrpc "github.com/containerd/ttrpc"
+
+func defaultHandshaker() ttrpc.Handshaker {
+	return nil
+}

--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -73,7 +73,7 @@ func dumpMetadata(ctx context.Context) {
 
 func server() error {
 	s, err := ttrpc.NewServer(
-		ttrpc.WithServerHandshaker(ttrpc.UnixSocketRequireSameUser()),
+		ttrpc.WithServerHandshaker(defaultHandshaker()),
 		ttrpc.WithUnaryServerInterceptor(serverIntercept),
 	)
 	if err != nil {

--- a/server_linux_test.go
+++ b/server_linux_test.go
@@ -1,0 +1,142 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ttrpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/procfs"
+)
+
+func TestUnixSocketHandshake(t *testing.T) {
+	var (
+		ctx             = context.Background()
+		server          = mustServer(t)(NewServer(WithServerHandshaker(UnixSocketRequireSameUser())))
+		addr, listener  = newTestListener(t)
+		errs            = make(chan error, 1)
+		client, cleanup = newTestClient(t, addr)
+	)
+	defer cleanup()
+	defer listener.Close()
+	go func() {
+		errs <- server.Serve(ctx, listener)
+	}()
+
+	registerTestingService(server, &testingServer{})
+
+	var tp testPayload
+	// server shutdown, but we still make a call.
+	if err := client.Call(ctx, serviceName, "Test", &tp, &tp); err != nil {
+		t.Fatalf("unexpected error making call: %v", err)
+	}
+}
+
+func BenchmarkRoundTripUnixSocketCreds(b *testing.B) {
+	// TODO(stevvooe): Right now, there is a 5x performance decrease when using
+	// unix socket credentials. See (UnixCredentialsFunc).Handshake for
+	// details.
+
+	var (
+		ctx             = context.Background()
+		server          = mustServer(b)(NewServer(WithServerHandshaker(UnixSocketRequireSameUser())))
+		testImpl        = &testingServer{}
+		addr, listener  = newTestListener(b)
+		client, cleanup = newTestClient(b, addr)
+		tclient         = newTestingClient(client)
+	)
+
+	defer listener.Close()
+	defer cleanup()
+
+	registerTestingService(server, testImpl)
+
+	go server.Serve(ctx, listener)
+	defer server.Shutdown(ctx)
+
+	var tp testPayload
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := tclient.Test(ctx, &tp); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestServerEOF(t *testing.T) {
+	var (
+		ctx             = context.Background()
+		server          = mustServer(t)(NewServer())
+		addr, listener  = newTestListener(t)
+		client, cleanup = newTestClient(t, addr)
+	)
+	defer cleanup()
+	defer listener.Close()
+
+	socketCountBefore := socketCount(t)
+
+	go server.Serve(ctx, listener)
+
+	registerTestingService(server, &testingServer{})
+
+	tp := &testPayload{}
+	// do a regular call
+	if err := client.Call(ctx, serviceName, "Test", tp, tp); err != nil {
+		t.Fatalf("unexpected error during test call: %v", err)
+	}
+
+	// close the client, so that server gets EOF
+	if err := client.Close(); err != nil {
+		t.Fatalf("unexpected error while closing client: %v", err)
+	}
+
+	// server should eventually close the client connection
+	maxAttempts := 20
+	for i := 1; i <= maxAttempts; i++ {
+		socketCountAfter := socketCount(t)
+		if socketCountAfter < socketCountBefore {
+			break
+		}
+		if i == maxAttempts {
+			t.Fatalf("expected number of open sockets to be less than %d after client close, got %d open sockets",
+				socketCountBefore, socketCountAfter)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func socketCount(t *testing.T) int {
+	proc, err := procfs.Self()
+	if err != nil {
+		t.Fatalf("unexpected error while reading procfs: %v", err)
+	}
+	fds, err := proc.FileDescriptorTargets()
+	if err != nil {
+		t.Fatalf("unexpected error while listing open file descriptors: %v", err)
+	}
+
+	sockets := 0
+	for _, fd := range fds {
+		if strings.Contains(fd, "socket") {
+			sockets++
+		}
+	}
+	return sockets
+}

--- a/server_test.go
+++ b/server_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	"github.com/prometheus/procfs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -366,71 +366,6 @@ func TestClientEOF(t *testing.T) {
 	}
 }
 
-func TestServerEOF(t *testing.T) {
-	var (
-		ctx             = context.Background()
-		server          = mustServer(t)(NewServer())
-		addr, listener  = newTestListener(t)
-		client, cleanup = newTestClient(t, addr)
-	)
-	defer cleanup()
-	defer listener.Close()
-
-	socketCountBefore := socketCount(t)
-
-	go server.Serve(ctx, listener)
-
-	registerTestingService(server, &testingServer{})
-
-	tp := &testPayload{}
-	// do a regular call
-	if err := client.Call(ctx, serviceName, "Test", tp, tp); err != nil {
-		t.Fatalf("unexpected error during test call: %v", err)
-	}
-
-	// close the client, so that server gets EOF
-	if err := client.Close(); err != nil {
-		t.Fatalf("unexpected error while closing client: %v", err)
-	}
-
-	// server should eventually close the client connection
-	maxAttempts := 20
-	for i := 1; i <= maxAttempts; i++ {
-		socketCountAfter := socketCount(t)
-		if socketCountAfter < socketCountBefore {
-			break
-		}
-		if i == maxAttempts {
-			t.Fatalf("expected number of open sockets to be less than %d after client close, got %d open sockets",
-				socketCountBefore, socketCountAfter)
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-func TestUnixSocketHandshake(t *testing.T) {
-	var (
-		ctx             = context.Background()
-		server          = mustServer(t)(NewServer(WithServerHandshaker(UnixSocketRequireSameUser())))
-		addr, listener  = newTestListener(t)
-		errs            = make(chan error, 1)
-		client, cleanup = newTestClient(t, addr)
-	)
-	defer cleanup()
-	defer listener.Close()
-	go func() {
-		errs <- server.Serve(ctx, listener)
-	}()
-
-	registerTestingService(server, &testingServer{})
-
-	var tp testPayload
-	// server shutdown, but we still make a call.
-	if err := client.Call(ctx, serviceName, "Test", &tp, &tp); err != nil {
-		t.Fatalf("unexpected error making call: %v", err)
-	}
-}
-
 func TestServerRequestTimeout(t *testing.T) {
 	var (
 		ctx, cancel     = context.WithDeadline(context.Background(), time.Now().Add(10*time.Minute))
@@ -534,38 +469,6 @@ func BenchmarkRoundTrip(b *testing.B) {
 	}
 }
 
-func BenchmarkRoundTripUnixSocketCreds(b *testing.B) {
-	// TODO(stevvooe): Right now, there is a 5x performance decrease when using
-	// unix socket credentials. See (UnixCredentialsFunc).Handshake for
-	// details.
-
-	var (
-		ctx             = context.Background()
-		server          = mustServer(b)(NewServer(WithServerHandshaker(UnixSocketRequireSameUser())))
-		testImpl        = &testingServer{}
-		addr, listener  = newTestListener(b)
-		client, cleanup = newTestClient(b, addr)
-		tclient         = newTestingClient(client)
-	)
-
-	defer listener.Close()
-	defer cleanup()
-
-	registerTestingService(server, testImpl)
-
-	go server.Serve(ctx, listener)
-	defer server.Shutdown(ctx)
-
-	var tp testPayload
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		if _, err := tclient.Test(ctx, &tp); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func checkServerShutdown(t *testing.T, server *Server) {
 	t.Helper()
 	server.mu.Lock()
@@ -620,7 +523,13 @@ func newTestClient(t testing.TB, addr string, opts ...ClientOpts) (*Client, func
 }
 
 func newTestListener(t testing.TB) (string, net.Listener) {
-	addr := "\x00" + t.Name()
+	var prefix string
+
+	// Abstracts sockets are only available on Linux.
+	if runtime.GOOS == "linux" {
+		prefix = "\x00"
+	}
+	addr := prefix + t.Name()
 	listener, err := net.Listen("unix", addr)
 	if err != nil {
 		t.Fatal(err)
@@ -638,23 +547,4 @@ func mustServer(t testing.TB) func(server *Server, err error) *Server {
 
 		return server
 	}
-}
-
-func socketCount(t *testing.T) int {
-	proc, err := procfs.Self()
-	if err != nil {
-		t.Fatalf("unexpected error while reading procfs: %v", err)
-	}
-	fds, err := proc.FileDescriptorTargets()
-	if err != nil {
-		t.Fatalf("unexpected error while listing open file descriptors: %v", err)
-	}
-
-	sockets := 0
-	for _, fd := range fds {
-		if strings.Contains(fd, "socket") {
-			sockets++
-		}
-	}
-	return sockets
 }


### PR DESCRIPTION
Abstract sockets, procfs and unix.Ucred are only available on Linux.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>