### PR TITLE
client: add synchronize between userCloseFunc and rpc call

### DIFF
--- a/client.go
+++ b/client.go
@@ -172,6 +172,8 @@ func (c *Client) dispatch(ctx context.Context, req *Request, resp *Response) err
 
 func (c *Client) Close() error {
 	c.closeOnce.Do(func() {
+		// let userCloseFunc in which func the resources are cleanuped finish before rpc call return
+		c.userCloseFunc()
 		c.closed()
 	})
 	return nil
@@ -263,7 +265,6 @@ func (c *Client) run() {
 
 	defer func() {
 		c.conn.Close()
-		c.userCloseFunc()
 		close(c.userCloseWaitCh)
 	}()
 


### PR DESCRIPTION
when containerd runtime plugin exites abnormally, ttrpc connection will closed
and userCloseFunc will be called to handle cleanup the resources created by
containerd shim. current rpc call will also return err. But these two step are
asynchronous.

after rpc call return err, upper application such as k8s may restart container.
but start may fail due to cleanup not finish, some resources not be released.
and this leaked resources leads to failed inplace-update the pod again.