### PR TITLE
Wrap correct error on unix.GetsockoptUcred failure

### DIFF
--- a/unixcreds_linux.go
+++ b/unixcreds_linux.go
@@ -50,7 +50,7 @@ func (fn UnixCredentialsFunc) Handshake(ctx context.Context, conn net.Conn) (net
 	}
 
 	if ucredErr != nil {
-		return nil, nil, fmt.Errorf("ttrpc.UnixCredentialsFunc: failed to retrieve socket peer credentials: %w", err)
+		return nil, nil, fmt.Errorf("ttrpc.UnixCredentialsFunc: failed to retrieve socket peer credentials: %w", ucredErr)
 	}
 
 	if err := fn(ucred); err != nil {


### PR DESCRIPTION
Wrap ucredErr which is set by unix.GetsockoptUcred, not the nil err.