### PR TITLE
Use CR+LF instead of LF regardless of OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf


### PR DESCRIPTION
Git by default uses CR+LF on Windows, whereas gofmt always
uses LF even on Windows.

This commit lets Git uses LF on Windows.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>