### PR TITLE
Enable Codecov again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,13 @@ jobs:
     - name: Test
       working-directory: src/github.com/containerd/ttrpc
       run: |
-        go test -v -race ./...
+        go test -v -race -coverprofile=coverage_txt -covermode=atomic ./...
+
+    - name: Code Coverage
+      uses: codecov/codecov-action@v2
+      with:
+        files: coverage_txt
+      if: matrix.os == 'ubuntu-latest'
 
   #
   # Run Protobuild


### PR DESCRIPTION
We have lost Codecov since #101. While the main containerd repository
doesn't have that, ttrpc could have Codecov without much complications.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>