### PR TITLE
*.go: organize errors to one spot

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -19,7 +19,6 @@ package ttrpc
 import (
 	"bufio"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -60,8 +59,6 @@ const (
 	flagRemoteOpen   uint8 = 0x2
 	flagNoData       uint8 = 0x4
 )
-
-var ErrProtocol = errors.New("protocol error")
 
 // messageHeader represents the fixed-length message header of 10 bytes sent
 // with every request.

--- a/client.go
+++ b/client.go
@@ -33,10 +33,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// ErrClosed is returned by client methods when the underlying connection is
-// closed.
-var ErrClosed = errors.New("ttrpc: closed")
-
 // Client for a ttrpc server
 type Client struct {
 	codec   codec

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,34 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ttrpc
+
+import "errors"
+
+var (
+	// ErrProtocol is a general error in the handling the protocol.
+	ErrProtocol = errors.New("protocol error")
+
+	// ErrClosed is returned by client methods when the underlying connection is
+	// closed.
+	ErrClosed = errors.New("ttrpc: closed")
+
+	// ErrServerClosed is returned when the Server has closed its connection.
+	ErrServerClosed = errors.New("ttrpc: server closed")
+
+	// ErrStreamClosed is when the streaming connection is closed.
+	ErrStreamClosed = errors.New("ttrpc: stream closed")
+)

--- a/server.go
+++ b/server.go
@@ -18,7 +18,6 @@ package ttrpc
 
 import (
 	"context"
-	"errors"
 	"io"
 	"math/rand"
 	"net"
@@ -29,10 +28,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-)
-
-var (
-	ErrServerClosed = errors.New("ttrpc: server closed")
 )
 
 type Server struct {

--- a/stream.go
+++ b/stream.go
@@ -18,11 +18,8 @@ package ttrpc
 
 import (
 	"context"
-	"errors"
 	"sync"
 )
-
-var ErrStreamClosed = errors.New("ttrpc: stream closed")
 
 type streamID uint32
 


### PR DESCRIPTION
And add a little documentation.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>