### PR TITLE
*: remove codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,18 +84,17 @@ jobs:
     - name: Test
       working-directory: src/github.com/containerd/ttrpc
       run: |
+        make test
+
+    - name: Coverage
+      working-directory: src/github.com/containerd/ttrpc
+      run: |
         make coverage TESTFLAGS_RACE=-race
 
     - name: Integration Tests
       working-directory: src/github.com/containerd/ttrpc
       run: |
         make integration
-
-    - name: Code Coverage
-      uses: codecov/codecov-action@v2
-      with:
-        files: coverage.txt
-      if: matrix.os == 'ubuntu-latest'
 
   #
   # Run Protobuild

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ttrpc
 
 [![Build Status](https://github.com/containerd/ttrpc/workflows/CI/badge.svg)](https://github.com/containerd/ttrpc/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/containerd/ttrpc/branch/main/graph/badge.svg)](https://codecov.io/gh/containerd/ttrpc)
 
 GRPC for low-memory environments.
 


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

From the slack conversation, it seems this codecov report is not useful and not quite accurate. It fails to reference git commits, and lists files that do not exist. I think getting a trusted local make target is a better focus.