### PR TITLE
Log dl.UnixNano() if this test fails

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -402,9 +402,11 @@ func TestServerRequestTimeout(t *testing.T) {
 		t.Fatalf("unexpected error making call: %v", err)
 	}
 
+	// The server implementation sets the context's deadline to result.Deadline.
+	// So the following condition should be true, even the host is really slow.
 	dl, _ := ctx.Deadline()
 	if result.Deadline != dl.UnixNano() {
-		t.Fatalf("expected deadline %v, actual: %v", dl, result.Deadline)
+		t.Fatalf("expected deadline %v, actual: %v", dl.UnixNano(), result.Deadline)
 	}
 }
 


### PR DESCRIPTION
Before this change, dl was logged like
`2022-04-20 21:22:18.3615054 +0000 GMT m=+601.172479801`, but
actual was like `1650489738361505500`.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>