### PR TITLE
build: Fix references to check-protos target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ TESTFLAGS_PARALLEL ?= 8
 # Use this to replace `go test` with, for instance, `gotestsum`
 GOTEST ?= $(GO) test
 
-.PHONY: clean all AUTHORS build binaries test integration generate protos checkprotos coverage ci check help install vendor install-protobuf install-protobuild
+.PHONY: clean all AUTHORS build binaries test integration generate protos check-protos coverage ci check help install vendor install-protobuf install-protobuild
 .DEFAULT: default
 
 # Forcibly set the default goal to all, in case an include above brought in a rule definition.
@@ -69,7 +69,7 @@ check: proto-fmt ## run all linters
 	@echo "$(WHALE) $@"
 	GOGC=75 golangci-lint run
 
-ci: check binaries checkprotos coverage # coverage-integration ## to be used by the CI
+ci: check binaries check-protos coverage # coverage-integration ## to be used by the CI
 
 AUTHORS: .mailmap .git/HEAD
 	git log --format='%aN <%aE>' | sort -fu > $@


### PR DESCRIPTION
There is no Makefile target for `checkprotos` -- this is a typo of the `check-protos` target. This PR fixes those references.

Signed-off-by: Ethan Lowman <ethan.lowman@datadoghq.com>