### PR TITLE
server: Fix connection issues when receiving ECONNRESET

### DIFF
--- a/server.go
+++ b/server.go
@@ -18,11 +18,13 @@ package ttrpc
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"net"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -525,14 +527,12 @@ func (c *serverConn) run(sctx context.Context) {
 			// branch. Basically, it means that we are no longer receiving
 			// requests due to a terminal error.
 			recvErr = nil // connection is now "closing"
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || err == io.ErrUnexpectedEOF || errors.Is(err, syscall.ECONNRESET) {
 				// The client went away and we should stop processing
 				// requests, so that the client connection is closed
 				return
 			}
-			if err != nil {
-				logrus.WithError(err).Error("error receiving message")
-			}
+			logrus.WithError(err).Error("error receiving message")
 			// else, initiate shutdown
 		case <-shutdown:
 			return


### PR DESCRIPTION
The ttrpc server somtimes receives `ECONNRESET` rather than `EOF` when the client is exited. Such as reading from a closed connection. Handle it properly to avoid goroutine and connection leak.

Below is a debug example:
```
> github.com/containerd/ttrpc.(*serverConn).run() containerd/ttrpc/server.go:470 (hits goroutine(23900):1 total:3) (PC: 0x55f06b5a7cb3)
(dlv) p err
error(*errors.errorString) *{s: "EOF"}
(dlv) c
> github.com/containerd/ttrpc.(*serverConn).run() containerd/ttrpc/server.go:470 (hits goroutine(47938):1 total:4) (PC: 0x55f06b5a7cb3)
(dlv) p err
error(*net.OpError) *{
        Op: "read",
        Net: "unix",
        Source: net.Addr(*net.UnixAddr) *{
                Name: "/run/containerd/containerd.sock.ttrpc",
                Net: "unix",},
        Addr: net.Addr(*net.UnixAddr) *{Name: "@", Net: "unix"},
        Err: error(*os.SyscallError) *{
                Syscall: "read",
                Err: error(syscall.Errno) *(*error)(0xc001840950),},}
(dlv) p err.Err
error(*os.SyscallError) *{
        Syscall: "read",
        Err: error(syscall.Errno) ECONNRESET (104),}
```

----------

Currently there's a possible race condition when shutting down the
server, which causes new connection to be added after `Shutdown()`

```
//s.Serve
l.Accept()
handshaker.Handshake
.
.       // s.Shutdown()
.        --> close(s.done)
.        --> closeListeners
.        --> closeIdleConns // should have no more conns after
.
s.newConn // An unexpected new conn is added
```