### PR TITLE
Block sending of oversize messages

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -143,10 +143,11 @@ func (ch *channel) recv() (messageHeader, []byte, error) {
 }
 
 func (ch *channel) send(streamID uint32, t messageType, flags uint8, p []byte) error {
-	// TODO: Error on send rather than on recv
-	//if len(p) > messageLengthMax {
-	//	return status.Errorf(codes.InvalidArgument, "refusing to send, message length %v exceed maximum message size of %v", len(p), messageLengthMax)
-	//}
+	if len(p) > messageLengthMax {
+		defer ch.conn.Close()
+		return status.Errorf(codes.ResourceExhausted, "refusing to send, message length %v exceed maximum message size of %v", len(p), messageLengthMax)
+	}
+
 	if err := writeMessageHeader(ch.bw, ch.hwbuf[:], messageHeader{Length: uint32(len(p)), StreamID: streamID, Type: t, Flags: flags}); err != nil {
 		return err
 	}

--- a/channel_test.go
+++ b/channel_test.go
@@ -102,23 +102,22 @@ func TestMessageOversize(t *testing.T) {
 	}()
 
 	_, _, err := rch.recv()
-	if err == nil {
-		t.Fatalf("error expected reading with small buffer")
-	}
-
-	status, ok := status.FromError(err)
-	if !ok {
-		t.Fatalf("expected grpc status error: %v", err)
-	}
-
-	if status.Code() != codes.ResourceExhausted {
-		t.Fatalf("expected grpc status code: %v != %v", status.Code(), codes.ResourceExhausted)
+	if err != nil {
+		status, _ := status.FromError(err)
+		if status.Code() == codes.ResourceExhausted {
+			t.Fatalf("no error expected, oversize message should not be send.")
+		}
 	}
 
 	select {
 	case err := <-errs:
-		if err != nil {
-			t.Fatal(err)
+		status, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("expected grpc status error: %v", err)
+		}
+
+		if status.Code() != codes.ResourceExhausted {
+			t.Fatalf("expected grpc status code: %v != %v", status.Code(), codes.ResourceExhausted)
 		}
 	default:
 	}


### PR DESCRIPTION
While looking to solve the containerd bug #6248 (https://github.com/containerd/containerd/issues/6248#issue-1053682568) I saw that it was already solved but the message would only be checked for the length after sending.  Like @dmcgowan noted the message should not even be sent because it will be discarded anyway. I changed the code so that the send function will check for the size and not send the message in case the length is longer than the max message length. I opted for an GRPC error code 8 (RESOURCE_EXHAUSTED) over error code 3 (INVALID_ARGUMENT) because it describes the error better.
I hope that this is what we were looking for and I'm open to any input.