### PR TITLE
Rework deadline assertion logging to be more clear

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -404,7 +404,7 @@ func TestServerRequestTimeout(t *testing.T) {
 
 	dl, _ := ctx.Deadline()
 	if result.Deadline != dl.UnixNano() {
-		t.Fatalf("expected deadline %v, actual: %v", dl, result.Deadline)
+		t.Fatalf("expected deadline %v, actual: %v", dl, time.Unix(0, result.Deadline))
 	}
 }
 


### PR DESCRIPTION
Make `TestServerRequestTimeout` deadline assertion log print expected
and actual values in the same format for more clear troubleshooting.

For troubleshooting #131

Signed-off-by: Austin Vazquez <macedonv@amazon.com>