### PR TITLE
[release/1.1] server: Fix connection leak when receiving ECONNRESET

### DIFF
--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -467,14 +468,12 @@ func (c *serverConn) run(sctx context.Context) {
 			// branch. Basically, it means that we are no longer receiving
 			// requests due to a terminal error.
 			recvErr = nil // connection is now "closing"
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || err == io.ErrUnexpectedEOF || errors.Is(err, syscall.ECONNRESET) {
 				// The client went away and we should stop processing
 				// requests, so that the client connection is closed
 				return
 			}
-			if err != nil {
-				logrus.WithError(err).Error("error receiving message")
-			}
+			logrus.WithError(err).Error("error receiving message")
 		case <-shutdown:
 			return
 		}


### PR DESCRIPTION
The ttrpc server somtimes receives `ECONNRESET` rather than `EOF` when the client is exited. Such as reading from a closed connection. Handle it properly to avoid goroutine and connection leak.

Change-Id: If32711cfc1347dd2da27ca846dd13c3f5af351bb

(cherry picked from commit a03aa0459192f20913133e3d1e71419414431c6f)

Fix for branch used by containerd 1.6