### PR TITLE
Unwrap IO errors in server connection error handling

### DIFF
--- a/server.go
+++ b/server.go
@@ -547,7 +547,7 @@ func (c *serverConn) run(sctx context.Context) {
 			// branch. Basically, it means that we are no longer receiving
 			// requests due to a terminal error.
 			recvErr = nil // connection is now "closing"
-			if err == io.EOF || err == io.ErrUnexpectedEOF || errors.Is(err, syscall.ECONNRESET) {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET) {
 				// The client went away and we should stop processing
 				// requests, so that the client connection is closed
 				return


### PR DESCRIPTION
Fixes #142 

Unwrap `io.EOF` and `io.ErrUnexpectedEOF` in server connection receive error handling. When read message errors occurs, the error is wrapped to be more distinguishable from read message header errors; however, without unwrapping the errors here the result would be leaked server connections for connections where the client is now gone.

Signed-of-by: Austin Vazquez <macedonv@amazon.com>