### PR TITLE
server_test: wait for OnClose in TestClientEOF.

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -363,6 +363,8 @@ func TestClientEOF(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	client.UserOnCloseWait(ctx)
+
 	// server shutdown, but we still make a call.
 	if err := client.Call(ctx, serviceName, "Test", tp, tp); err == nil {
 		t.Fatalf("expected error when calling against shutdown server")


### PR DESCRIPTION
In the test for client `Call()` failing with `ErrClosed` on a closed server, wait for the client's `OnClose()` handler to get triggered to make sure closing the socket had properly been administered on the client's side. Otherwise trying a new `Call()` might fail with some other error than `ErrClosed`, for instance `ENOTCONN`.

This commit was split out from #145 as a PR of its own.