### PR TITLE
Fix grammar in comment for UserOnCloseWait.

### DIFF
--- a/client.go
+++ b/client.go
@@ -286,7 +286,7 @@ func (c *Client) Close() error {
 	return nil
 }
 
-// UserOnCloseWait is used to blocks untils the user's on-close callback
+// UserOnCloseWait is used to block until the user's on-close callback
 // finishes.
 func (c *Client) UserOnCloseWait(ctx context.Context) error {
 	select {


### PR DESCRIPTION
While looking at `client.go:UserOnCloseWait()` based on a review comment for #150, I spotted something that looks like grammar errors in a docstring comment which then ends up being part of the package [documentation here](https://pkg.go.dev/github.com/containerd/ttrpc#Client.UserOnCloseWait).

Can some of the native speakers double-check that I didn't simply trade a grammar error for another one ?