### PR TITLE
Fix proto3 generation error

### DIFF
--- a/cmd/protoc-gen-go-ttrpc/main.go
+++ b/cmd/protoc-gen-go-ttrpc/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 func main() {
@@ -30,6 +31,7 @@ func main() {
 			return nil
 		},
 	}.Run(func(gen *protogen.Plugin) error {
+		gen.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 		for _, f := range gen.Files {
 			if !f.Generate {
 				continue


### PR DESCRIPTION
Fixes error
```
is a proto3 file that contains optional fields, but code generator protoc-gen-go-ttrpc hasn't been updated to support optional fields in proto3. Please ask the owner of this code generator to support proto3 optional.
```