### PR TITLE
[release/1.1] Fix context cancelled error after client close

### DIFF
--- a/client.go
+++ b/client.go
@@ -264,6 +264,7 @@ func (c *Client) run() {
 		for {
 			select {
 			case <-c.ctx.Done():
+				// The client has been closed, so the sender goroutine can now be stopped.
 				return
 			case call := <-c.calls:
 				id := streamID
@@ -288,7 +289,7 @@ func (c *Client) run() {
 		for {
 			select {
 			case <-c.ctx.Done():
-				c.setError(c.ctx.Err())
+				// The client has been closed, so the receiver goroutine can now be stopped.
 				return
 			default:
 				mh, p, err := c.channel.recv()


### PR DESCRIPTION
### Issue
#137 

### Description
Closes the receiver goroutine without setting the client error when the client is closed. Client error will be set on next dispatch call invoked if any.

### Testing
Adds unit test which calls test service call after client is closed. Before the change, the test failed 1 in every ~3000 runs. After the change, the test passed successfully 10000 runs in a row.

Run test:
```
go test -timeout 300s -tags unit,integration -run ^TestClientReturnsErrClosedAfterClose$ github.com/containerd/ttrpc -v -race -count=10000
```

Test failure without fix:
```
=== RUN   TestClientReturnsErrClosedAfterClose
    client_test.go:100: Expected ErrClosed after connection has been closed, got context canceled
--- FAIL: TestClientReturnsErrClosedAfterClose (0.00s)
FAIL
FAIL    github.com/containerd/ttrpc     0.648s
FAIL
```

Output:
```
=== RUN   TestClientReturnsErrClosedAfterClose
--- PASS: TestClientReturnsErrClosedAfterClose (0.00s)
=== RUN   TestClientReturnsErrClosedAfterClose
--- PASS: TestClientReturnsErrClosedAfterClose (0.00s)
=== RUN   TestClientReturnsErrClosedAfterClose
--- PASS: TestClientReturnsErrClosedAfterClose (0.00s)
PASS
ok      github.com/containerd/ttrpc     7.583s
```

### Alternative solutions considered
Considered setting the client error to `ErrClosed` when the receive goroutine exits on context cancel. I decided against this as closing the client is not an error until a call is made on a closed client which would result in the error being set to `ErrClosed`.