### PR TITLE
Update GitHub Actions CI to resolve deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/ttrpc
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.51.2
           args: --timeout=5m
@@ -57,14 +57,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/ttrpc
           fetch-depth: 25
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: containerd/project-checks@v1.1.0
         with:
@@ -85,15 +85,15 @@ jobs:
     timeout-minutes: 10
     steps:
 
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
-
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: src/github.com/containerd/ttrpc
         fetch-depth: 25
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go }}
 
     - name: Test
       working-directory: src/github.com/containerd/ttrpc
@@ -119,7 +119,13 @@ jobs:
     timeout-minutes: 5
     steps:
 
-    - uses: actions/setup-go@v3
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        path: src/github.com/containerd/ttrpc
+        fetch-depth: 25
+
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -129,12 +135,6 @@ jobs:
       run: |
         echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-
-    - name: Check out code
-      uses: actions/checkout@v3
-      with:
-        path: src/github.com/containerd/ttrpc
-        fetch-depth: 25
 
     - name: Install dependencies
       working-directory: src/github.com/containerd/ttrpc


### PR DESCRIPTION
### Issue
NodeJS 16 is EOL and GitHub Actions packages have been releases to run on NodeJS 20.

<img width="1777" alt="image" src="https://github.com/containerd/ttrpc/assets/55906459/0cbaa0ee-22e3-4710-82ec-029443129d01">

### Description
This change updates the GitHub Actions packages to resolve deprecation warnings

### Testing
CI runs on PR

### Additional context
- https://nodejs.org/en/blog/announcements/nodejs16-eol
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/