### PR TITLE
[release/1.1] Backport CI updates and enable CI on release 1.1 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,82 +6,75 @@ on:
   pull_request:
     branches: [ main ]
 
-jobs:
+env:
+  GO_VERSION: 1.20.x
 
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  #
+  # Project checks
+  #
+  project:
+    name: Project Checks
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v3
+        with:
+          path: src/github.com/containerd/ttrpc
+          fetch-depth: 25
+
+      - uses: containerd/project-checks@v1.1.0
+        with:
+          working-directory: src/github.com/containerd/ttrpc
+
+  #
+  # Build and Test project
+  #
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
-    name: ${{ matrix.os }}
+        os: [ubuntu-latest, macos-latest]
+        go: [1.19.x, 1.20.x]
+
+    name: ${{ matrix.os }} / ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
 
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.15
-      id: go
-
-    - name: Setup Go binary path
-      shell: bash
-      run: |
-        echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
-        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+        go-version: ${{ matrix.go }}
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/ttrpc
         fetch-depth: 25
 
-    - name: Checkout project
-      uses: actions/checkout@v2
-      with:
-        repository: containerd/project
-        path: src/github.com/containerd/project
-
-    - name: Install dependencies
-      env:
-        GO111MODULE: off
-      run: |
-        go get -u github.com/vbatts/git-validation
-        go get -u github.com/kunalkushwaha/ltag
-
-    - name: Check DCO/whitespace/commit message
-      env:
-        GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
-        DCO_VERBOSITY: "-q"
-        DCO_RANGE: ""
-      working-directory: src/github.com/containerd/ttrpc
-      run: |
-        if [ -z "${GITHUB_COMMIT_URL}" ]; then
-          DCO_RANGE=$(jq -r '.before +".."+ .after' ${GITHUB_EVENT_PATH})
-        else
-          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
-        fi
-        ../project/script/validate/dco
-
-    - name: Check file headers
-      run: ../project/script/validate/fileheader ../project/
-      working-directory: src/github.com/containerd/ttrpc
-
     - name: Test
       working-directory: src/github.com/containerd/ttrpc
       run: |
-        go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+        go test -v -race -coverprofile="coverage.txt" -covermode=atomic ./...
 
   protobuild:
     name: Run Protobuild
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
 
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Setup Go binary path
@@ -91,7 +84,7 @@ jobs:
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/ttrpc
         fetch-depth: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/ttrpc
           fetch-depth: 25
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: containerd/project-checks@v1.1.0
         with:
@@ -51,15 +51,15 @@ jobs:
     timeout-minutes: 5
     steps:
 
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
-
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: src/github.com/containerd/ttrpc
         fetch-depth: 25
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go }}
 
     - name: Test
       working-directory: src/github.com/containerd/ttrpc
@@ -72,7 +72,13 @@ jobs:
     timeout-minutes: 5
     steps:
 
-    - uses: actions/setup-go@v3
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        path: src/github.com/containerd/ttrpc
+        fetch-depth: 25
+
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -82,12 +88,6 @@ jobs:
       run: |
         echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-
-    - name: Check out code
-      uses: actions/checkout@v3
-      with:
-        path: src/github.com/containerd/ttrpc
-        fetch-depth: 25
 
     - name: Install protoc
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'release/**' ]
 
 env:
   GO_VERSION: 1.20.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,6 @@ jobs:
       run: |
         go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-    - name: Codecov
-      run: bash <(curl -s https://codecov.io/bash)
-      working-directory: src/github.com/containerd/ttrpc
-
   protobuild:
     name: Run Protobuild
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ttrpc
 
 [![Build Status](https://github.com/containerd/ttrpc/workflows/CI/badge.svg)](https://github.com/containerd/ttrpc/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/containerd/ttrpc/branch/main/graph/badge.svg)](https://codecov.io/gh/containerd/ttrpc)
 
 GRPC for low-memory environments.
 


### PR DESCRIPTION
### Issue
The release/1.1 branch currently has no CI for validating changes.

### Description
This change backports the following CI updates and enables CI for the branch.

- https://github.com/containerd/ttrpc/commit/9660e6b7a5fc1929620f5ebd29db756a4e992214 - remove codecov
- https://github.com/containerd/ttrpc/commit/c7b5a322eda63419e2dafa8dd215b08739ebe9f5 - update GitHub Actions CI workflow Note: drops unit testing on windows-latest due to test failure for unhandled edge case on Windows. Opened #164 
- https://github.com/containerd/ttrpc/commit/589a593abc38264094c47baf83bc69b2cff37524 - update GitHub Actions CI to resolve deprecation warnings