### PR TITLE
[release/1.1] Fix windows closed pipe error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go: [1.19.x, 1.20.x]
 
     name: ${{ matrix.os }} / ${{ matrix.go }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,82 +6,75 @@ on:
   pull_request:
     branches: [ main ]
 
-jobs:
+env:
+  GO_VERSION: 1.20.x
 
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  #
+  # Project checks
+  #
+  project:
+    name: Project Checks
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v3
+        with:
+          path: src/github.com/containerd/ttrpc
+          fetch-depth: 25
+
+      - uses: containerd/project-checks@v1.1.0
+        with:
+          working-directory: src/github.com/containerd/ttrpc
+
+  #
+  # Build and Test project
+  #
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
-    name: ${{ matrix.os }}
+        os: [ubuntu-latest, macos-latest]
+        go: [1.19.x, 1.20.x]
+
+    name: ${{ matrix.os }} / ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
 
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.15
-      id: go
-
-    - name: Setup Go binary path
-      shell: bash
-      run: |
-        echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
-        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+        go-version: ${{ matrix.go }}
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/ttrpc
         fetch-depth: 25
 
-    - name: Checkout project
-      uses: actions/checkout@v2
-      with:
-        repository: containerd/project
-        path: src/github.com/containerd/project
-
-    - name: Install dependencies
-      env:
-        GO111MODULE: off
-      run: |
-        go get -u github.com/vbatts/git-validation
-        go get -u github.com/kunalkushwaha/ltag
-
-    - name: Check DCO/whitespace/commit message
-      env:
-        GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
-        DCO_VERBOSITY: "-q"
-        DCO_RANGE: ""
-      working-directory: src/github.com/containerd/ttrpc
-      run: |
-        if [ -z "${GITHUB_COMMIT_URL}" ]; then
-          DCO_RANGE=$(jq -r '.before +".."+ .after' ${GITHUB_EVENT_PATH})
-        else
-          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
-        fi
-        ../project/script/validate/dco
-
-    - name: Check file headers
-      run: ../project/script/validate/fileheader ../project/
-      working-directory: src/github.com/containerd/ttrpc
-
     - name: Test
       working-directory: src/github.com/containerd/ttrpc
       run: |
-        go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+        go test -v -race -coverprofile="coverage.txt" -covermode=atomic ./...
 
   protobuild:
     name: Run Protobuild
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
 
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Setup Go binary path
@@ -91,7 +84,7 @@ jobs:
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/ttrpc
         fetch-depth: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/ttrpc
           fetch-depth: 25
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: containerd/project-checks@v1.1.0
         with:
@@ -51,15 +51,15 @@ jobs:
     timeout-minutes: 5
     steps:
 
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
-
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: src/github.com/containerd/ttrpc
         fetch-depth: 25
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go }}
 
     - name: Test
       working-directory: src/github.com/containerd/ttrpc
@@ -72,7 +72,13 @@ jobs:
     timeout-minutes: 5
     steps:
 
-    - uses: actions/setup-go@v3
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        path: src/github.com/containerd/ttrpc
+        fetch-depth: 25
+
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -82,12 +88,6 @@ jobs:
       run: |
         echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-
-    - name: Check out code
-      uses: actions/checkout@v3
-      with:
-        path: src/github.com/containerd/ttrpc
-        fetch-depth: 25
 
     - name: Install protoc
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'release/**' ]
 
 env:
   GO_VERSION: 1.20.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,6 @@ jobs:
       run: |
         go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-    - name: Codecov
-      run: bash <(curl -s https://codecov.io/bash)
-      working-directory: src/github.com/containerd/ttrpc
-
   protobuild:
     name: Run Protobuild
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ttrpc
 
 [![Build Status](https://github.com/containerd/ttrpc/workflows/CI/badge.svg)](https://github.com/containerd/ttrpc/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/containerd/ttrpc/branch/main/graph/badge.svg)](https://codecov.io/gh/containerd/ttrpc)
 
 GRPC for low-memory environments.
 

--- a/client.go
+++ b/client.go
@@ -390,6 +390,8 @@ func filterCloseErr(err error) error {
 		return ErrClosed
 	case errors.Is(err, io.EOF):
 		return ErrClosed
+	case errors.Is(err, io.ErrClosedPipe):
+		return ErrClosed
 	case strings.Contains(err.Error(), "use of closed network connection"):
 		return ErrClosed
 	default:


### PR DESCRIPTION
### Issue
#164 

### Description
This change adds `io.ErrClosedPipe` to client filter close error to enable unit tests to run on the Windows platform with Go 1.20+ toolchains.

### Testing
TestClientEOF passes on Windows platform with Go 1.20 toolchain