### PR TITLE
channel: reject oversized messages on the sender side(, too).

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -143,10 +143,10 @@ func (ch *channel) recv() (messageHeader, []byte, error) {
 }
 
 func (ch *channel) send(streamID uint32, t messageType, flags uint8, p []byte) error {
-	// TODO: Error on send rather than on recv
-	//if len(p) > messageLengthMax {
-	//	return status.Errorf(codes.InvalidArgument, "refusing to send, message length %v exceed maximum message size of %v", len(p), messageLengthMax)
-	//}
+	if len(p) > messageLengthMax {
+		return status.Errorf(codes.ResourceExhausted, "refusing to send, message length %v exceed maximum message size of %v", len(p), messageLengthMax)
+	}
+
 	if err := writeMessageHeader(ch.bw, ch.hwbuf[:], messageHeader{Length: uint32(len(p)), StreamID: streamID, Type: t, Flags: flags}); err != nil {
 		return err
 	}

--- a/channel.go
+++ b/channel.go
@@ -144,7 +144,7 @@ func (ch *channel) recv() (messageHeader, []byte, error) {
 
 func (ch *channel) send(streamID uint32, t messageType, flags uint8, p []byte) error {
 	if len(p) > messageLengthMax {
-		return status.Errorf(codes.ResourceExhausted, "refusing to send, message length %v exceed maximum message size of %v", len(p), messageLengthMax)
+		return OversizedMessageError(len(p))
 	}
 
 	if err := writeMessageHeader(ch.bw, ch.hwbuf[:], messageHeader{Length: uint32(len(p)), StreamID: streamID, Type: t, Flags: flags}); err != nil {


### PR DESCRIPTION
Reject oversized messages on the sender side (keeping the receiver side rejection code intact). Do not forcibly close in `channel.send()` the underlying connection when an oversized message is rejected.

This should provide minimal low-level means for ttrpc-based applications to detect oversized requests in `client.Call()` and attempt an application level recovery/corrective actions, if the high-level protocol is designed with this in mind.