### PR TITLE
server: fix a Serve() vs. (immediate) Shutdown() race

### DIFF
--- a/server.go
+++ b/server.go
@@ -74,8 +74,17 @@ func (s *Server) RegisterService(name string, desc *ServiceDesc) {
 }
 
 func (s *Server) Serve(ctx context.Context, l net.Listener) error {
-	s.addListener(l)
+	s.mu.Lock()
+	s.addListenerLocked(l)
 	defer s.closeListener(l)
+
+	select {
+	case <-s.done:
+		s.mu.Unlock()
+		return ErrServerClosed
+	default:
+	}
+	s.mu.Unlock()
 
 	var (
 		backoff    time.Duration
@@ -188,9 +197,7 @@ func (s *Server) Close() error {
 	return err
 }
 
-func (s *Server) addListener(l net.Listener) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (s *Server) addListenerLocked(l net.Listener) {
 	s.listeners[l] = struct{}{}
 }
 


### PR DESCRIPTION
Fix a race where an asynchronous server.Serve() invoked in a a goroutine races with an almost immediate server.Shutdown().

If Shutdown() finishes its locked closing of listeners before Serve() gets around to add the new one, Serve will sit stuck forever in l.Accept(), unless the caller closes the listener in addition to Shutdown().
    
This is probably almost impossible to trigger in real life, but unit tests which run the server and client in the same process can trigger this. If a test then tries to verify after a Shutdown()  a final ErrServerClosed error from Serve() it gets stuck forever.
