### PR TITLE
feat: edition support

### DIFF
--- a/cmd/protoc-gen-go-ttrpc/main.go
+++ b/cmd/protoc-gen-go-ttrpc/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
@@ -31,7 +32,12 @@ func main() {
 			return nil
 		},
 	}.Run(func(gen *protogen.Plugin) error {
-		gen.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+		gen.SupportedEditionsMinimum = descriptorpb.Edition_EDITION_PROTO3
+		gen.SupportedEditionsMaximum = descriptorpb.Edition_EDITION_MAX
+		gen.SupportedFeatures = uint64(
+			pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL |
+				pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS,
+		)
 		for _, f := range gen.Files {
 			if !f.Generate {
 				continue


### PR DESCRIPTION
This change adds support for editions (ex. `edition = "2023";`) in the `protoc-gen-ttrpc-go` generator.

For my use case I just needed to suppress the `edition not supported` errors from `protoc` so I am adding here in case anyone else needs it. 

I verified by compiling a `.proto` with `edition = "2023";` and observing no errors or problems. I am not sure the best way to seamlessly add this as a test here.

I read through [Implementing Editions Support](https://protobuf.dev/editions/implementation/) and I didn’t spot any extra changes needed in the generator. However, please feel free to make changes or suggest updates. 

For more info see: [Language Guide (editions)](https://protobuf.dev/programming-guides/editions/)
