### PR TITLE
server: cancel per-stream context when handler returns

### DIFF
--- a/server.go
+++ b/server.go
@@ -568,8 +568,6 @@ func (c *serverConn) run(sctx context.Context) {
 	}
 }
 
-var noopFunc = func() {}
-
 func getRequestContext(ctx context.Context, req *Request) (retCtx context.Context, cancel func()) {
 	if len(req.Metadata) > 0 {
 		md := MD{}
@@ -577,11 +575,10 @@ func getRequestContext(ctx context.Context, req *Request) (retCtx context.Contex
 		ctx = WithMetadata(ctx, md)
 	}
 
-	cancel = noopFunc
 	if req.TimeoutNano == 0 {
-		return ctx, cancel
+		// Cancellable so handlers' deferred cancel propagates to RecvMsg.
+		return context.WithCancel(ctx)
 	}
 
-	ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutNano))
-	return ctx, cancel
+	return context.WithTimeout(ctx, time.Duration(req.TimeoutNano))
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/containerd/ttrpc/internal"
 )
@@ -114,5 +115,61 @@ func TestStreamClient(t *testing.T) {
 	}
 	if err != io.EOF {
 		t.Fatalf("expected io.EOF after close send, got %v", err)
+	}
+}
+
+// TestStreamHandlerContextCancelOnReturn verifies that the context passed
+// to a stream handler is cancelled once the handler returns. Without this,
+// goroutines that the handler spawned and parked on `<-ctx.Done()` (for
+// example wrappers around RecvMsg) would only wake on connection close,
+// accumulating one leaked goroutine per completed stream.
+func TestStreamHandlerContextCancelOnReturn(t *testing.T) {
+	var (
+		ctx             = context.Background()
+		server          = mustServer(t)(NewServer())
+		addr, listener  = newTestListener(t)
+		client, cleanup = newTestClient(t, addr)
+		serviceName     = "streamCancelService"
+	)
+	defer listener.Close()
+	defer cleanup()
+
+	handlerCtx := make(chan context.Context, 1)
+	desc := &ServiceDesc{
+		Streams: map[string]Stream{
+			"Quick": {
+				Handler: func(hctx context.Context, _ StreamServer) (interface{}, error) {
+					handlerCtx <- hctx
+					return nil, nil
+				},
+				StreamingClient: true,
+				StreamingServer: true,
+			},
+		},
+	}
+	server.RegisterService(serviceName, desc)
+
+	go server.Serve(ctx, listener)
+	defer server.Shutdown(ctx)
+
+	stream, err := client.NewStream(ctx, &StreamDesc{StreamingClient: true, StreamingServer: true}, serviceName, "Quick", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.CloseSend()
+
+	var hctx context.Context
+	select {
+	case hctx = <-handlerCtx:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not run within 2s")
+	}
+
+	// After the handler returned, its per-stream ctx must be cancelled.
+	// Pre-fix this only happened on connection close.
+	select {
+	case <-hctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler ctx not cancelled after handler returned")
 	}
 }


### PR DESCRIPTION
## Summary

For stream RPCs without a request timeout, `getRequestContext` returned
`noopFunc` as the cancel. The deferred `cancel()` in `services.go`'s
stream-handling goroutine was therefore a no-op, and the per-stream
context only cancelled when the connection itself closed.

Any goroutine that parked on `<-s.ctx.Done()` (including direct calls
into `srv.RecvMsg` from handler-spawned helpers) therefore leaked one
stack frame and one entry in the server's `streams` sync.Map per
completed stream, accumulating for the lifetime of the connection.

Make the per-stream context cancellable so the existing deferred call
site actually propagates.

## Test

Adds `TestStreamHandlerContextCancelOnReturn`: the handler captures
its context, returns, and the test asserts the context is `Done` within
2s. Pre-fix the test fails with `handler ctx not cancelled after
handler returned`. Existing test suite passes; no other behavior
changes in this commit.

## Found via

A goroutine leak in a downstream streaming bridge that spawns a
helper goroutine calling `srv.RecvMsg` from inside the handler. After
the handler returned, that helper stayed parked on `<-s.ctx.Done()`
indefinitely. The shape matched `streamHandler.RecvMsg`'s select; the
root cause was the no-op cancel above.
