### PR TITLE
remove use of deprecated github.com/golang/protobuf aliase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/containerd/log v0.1.0
-	github.com/golang/protobuf v1.5.4
 	github.com/prometheus/procfs v0.6.0
 	golang.org/x/sys v0.46.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171

--- a/integration/streaming_test.go
+++ b/integration/streaming_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/ttrpc/integration/streaming"
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -132,7 +131,7 @@ func (tss *testStreamingService) DivideStream(_ context.Context, sum *streaming.
 	}
 	return nil
 }
-func (tss *testStreamingService) EchoNull(_ context.Context, es streaming.TTRPCStreaming_EchoNullServer) (*empty.Empty, error) {
+func (tss *testStreamingService) EchoNull(_ context.Context, es streaming.TTRPCStreaming_EchoNullServer) (*emptypb.Empty, error) {
 	msg := "non-empty empty"
 	for seq := uint32(0); ; seq++ {
 		var e streaming.EchoPayload
@@ -150,12 +149,12 @@ func (tss *testStreamingService) EchoNull(_ context.Context, es streaming.TTRPCS
 		}
 	}
 
-	return &empty.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 func (tss *testStreamingService) EchoNullStream(_ context.Context, es streaming.TTRPCStreaming_EchoNullStreamServer) error {
 	msg := "non-empty empty"
-	empty := &empty.Empty{}
+	empty := &emptypb.Empty{}
 	var wg sync.WaitGroup
 	var sendErr error
 	var errOnce sync.Once


### PR DESCRIPTION
The empty.Empty type is an alias for the new type;

https://github.com/golang/protobuf/blob/v1.5.4/ptypes/empty/empty.pb.go#L9-L15